### PR TITLE
Active route optimization

### DIFF
--- a/lib/views/active_route.dart
+++ b/lib/views/active_route.dart
@@ -244,7 +244,7 @@ class ActiveRouteState extends State<ActiveRoute> {
     toReturn.addAll(
       routeMeta.values
         .where((ModelField mf) => !mf.optional)
-        .where((ModelField mf) => (mf.type != FieldDataType.select && routeFields[mf.title].text.isEmpty)
+        .where((ModelField mf) => (mf.type != FieldDataType.select && (routeFields[mf.title].text.isEmpty || routeFields[mf.title].text.trim().isEmpty))
           || (mf.type == FieldDataType.select && !routeFieldsForDropdown.containsKey(mf.title)))
         .map((ModelField mf) => mf.title)
     );
@@ -255,7 +255,7 @@ class ActiveRouteState extends State<ActiveRoute> {
         fields.values
           .where((StopField sf) => !sf.optional)
           .where((StopField sf) => !stopMeta[stopTitle].exclude.contains(sf.title))
-          .where((StopField sf) => (sf.type != FieldDataType.select && stopFields[stopTitle][sf.title].text.isEmpty)
+          .where((StopField sf) => (sf.type != FieldDataType.select && (stopFields[stopTitle][sf.title].text.isEmpty || stopFields[stopTitle][sf.title].text.trim().isEmpty))
             || (sf.type == FieldDataType.select && !stopFieldsForDropdown[stopTitle].containsKey(sf.title)))
           .map((StopField sf) => '$stopTitle--${sf.title}')
       );

--- a/lib/views/active_route.dart
+++ b/lib/views/active_route.dart
@@ -662,40 +662,42 @@ class ActiveRouteState extends State<ActiveRoute> {
     int len = 2 + stopMeta.length;
     return Container(
       padding: const EdgeInsets.only(left: 10.0, right: 10.0, top: 30.0, bottom: 10.0),
-      // Listview *works*, but validation doesn't, since some form fields are NULL.
-      child: ListView.builder(
-        itemCount: len,
-        itemBuilder: (context, index) {
-          // first element is always the title card
-          if (index == 0) {
-            return ActiveRouteTitleCard(
+      child: Form(
+        key: _formKey,
+        child: ListView.builder(
+          itemCount: len,
+          itemBuilder: (context, index) {
+            // first element is always the title card
+            if (index == 0) {
+              return ActiveRouteTitleCard(
+                cardTextStyle: cardTextStyle,
+                title: widget.activeRoute.title,
+                routeMeta: routeMeta,
+                routeFields: routeFields,
+                routeFieldsForDropdown: routeFieldsForDropdown,
+                groupsMeta: groupsMeta,
+                onDropdownRouteFieldChanged: setRouteFieldForDropdown
+              );
+            }
+            // last element is always the submission area
+            if (index == len - 1) {
+              return _buildSubmissionArea();
+            }
+            int stopIndex = index - 1;
+            String thisStopTitle = ids[stopIndex];
+            return ActiveRouteStop(
               cardTextStyle: cardTextStyle,
-              title: widget.activeRoute.title,
-              routeMeta: routeMeta,
-              routeFields: routeFields,
-              routeFieldsForDropdown: routeFieldsForDropdown,
+              title: thisStopTitle,
+              stopMeta: stopMeta,
+              stopFieldsMeta: stopFieldsMeta,
+              enabled: !allPreviousSaves.contains(thisStopTitle),
+              stopFieldsForDropdown: stopFieldsForDropdown,
+              stopFields: stopFields,
               groupsMeta: groupsMeta,
-              onDropdownRouteFieldChanged: setRouteFieldForDropdown
+              onDropdownStopFieldChanged: setStopFieldForDropdown
             );
           }
-          // last element is always the submission area
-          if (index == len - 1) {
-            return _buildSubmissionArea();
-          }
-          int stopIndex = index - 1;
-          String thisStopTitle = ids[stopIndex];
-          return ActiveRouteStop(
-            cardTextStyle: cardTextStyle,
-            title: thisStopTitle,
-            stopMeta: stopMeta,
-            stopFieldsMeta: stopFieldsMeta,
-            enabled: !allPreviousSaves.contains(thisStopTitle),
-            stopFieldsForDropdown: stopFieldsForDropdown,
-            stopFields: stopFields,
-            groupsMeta: groupsMeta,
-            onDropdownStopFieldChanged: setStopFieldForDropdown
-          );
-        }
+        )
       )
     );
   }

--- a/lib/views/active_route.dart
+++ b/lib/views/active_route.dart
@@ -656,46 +656,43 @@ class ActiveRouteState extends State<ActiveRoute> {
         allPreviousSaves.addAll(rso.stops);
       });
     }
-    // build list of stops
-    List<String> ids = stopFieldsMeta.keys.toList();
 
-    int len = 2 + stopMeta.length;
+    List<Widget> listViewChildren = [];
+    // first element is always the title card
+    listViewChildren.add(
+      ActiveRouteTitleCard(
+        cardTextStyle: cardTextStyle,
+        title: widget.activeRoute.title,
+        routeMeta: routeMeta,
+        routeFields: routeFields,
+        routeFieldsForDropdown: routeFieldsForDropdown,
+        groupsMeta: groupsMeta,
+        onDropdownRouteFieldChanged: setRouteFieldForDropdown
+      )
+    );
+    stopFieldsMeta.keys.forEach((String thisStopTitle) {
+      listViewChildren.add(
+        ActiveRouteStop(
+          cardTextStyle: cardTextStyle,
+          title: thisStopTitle,
+          stopMeta: stopMeta,
+          stopFieldsMeta: stopFieldsMeta,
+          enabled: !allPreviousSaves.contains(thisStopTitle),
+          stopFieldsForDropdown: stopFieldsForDropdown,
+          stopFields: stopFields,
+          groupsMeta: groupsMeta,
+          onDropdownStopFieldChanged: setStopFieldForDropdown
+        )
+      );
+    });
+    // last element is always the submission area
+    listViewChildren.add(_buildSubmissionArea());
+
     return Container(
       padding: const EdgeInsets.only(left: 10.0, right: 10.0, top: 30.0, bottom: 10.0),
       // Listview *works*, but validation doesn't, since some form fields are NULL.
-      child: ListView.builder(
-        itemCount: len,
-        itemBuilder: (context, index) {
-          // first element is always the title card
-          if (index == 0) {
-            return ActiveRouteTitleCard(
-              cardTextStyle: cardTextStyle,
-              title: widget.activeRoute.title,
-              routeMeta: routeMeta,
-              routeFields: routeFields,
-              routeFieldsForDropdown: routeFieldsForDropdown,
-              groupsMeta: groupsMeta,
-              onDropdownRouteFieldChanged: setRouteFieldForDropdown
-            );
-          }
-          // last element is always the submission area
-          if (index == len - 1) {
-            return _buildSubmissionArea();
-          }
-          int stopIndex = index - 1;
-          String thisStopTitle = ids[stopIndex];
-          return ActiveRouteStop(
-            cardTextStyle: cardTextStyle,
-            title: thisStopTitle,
-            stopMeta: stopMeta,
-            stopFieldsMeta: stopFieldsMeta,
-            enabled: !allPreviousSaves.contains(thisStopTitle),
-            stopFieldsForDropdown: stopFieldsForDropdown,
-            stopFields: stopFields,
-            groupsMeta: groupsMeta,
-            onDropdownStopFieldChanged: setStopFieldForDropdown
-          );
-        }
+      child: ListView(
+        children: listViewChildren
       )
     );
   }

--- a/lib/views/active_route.dart
+++ b/lib/views/active_route.dart
@@ -649,52 +649,53 @@ class ActiveRouteState extends State<ActiveRoute> {
       return Loading();
     }
 
-    // int len = 2 + stopMeta.length;
-    // return Container(
-    //   padding: const EdgeInsets.only(left: 10.0, right: 10.0, top: 30.0, bottom: 10.0),
-    //   child: ListView.builder(
-    //     itemCount: len,
-    //     itemBuilder: (context, index) {
-    //       if (index == 0) {
-    //         return ActiveRouteTitleCard(
-    //           cardTextStyle: cardTextStyle,
-    //           title: widget.activeRoute.title,
-    //           routeMeta: routeMeta,
-    //           routeFields: routeFields,
-    //           routeFieldsForDropdown: routeFieldsForDropdown,
-    //           groupsMeta: groupsMeta,
-    //           onDropdownRouteFieldChanged: setRouteFieldForDropdown
-    //         );
-    //       }
-    //       if (index == len - 1) {
-    //
-    //       }
-    //       return someStop;
-    //     }
-    //   )
-    // );
+    // get stops included by all previous saves so we know if there are stops to grey out
+    List<String> allPreviousSaves = [];
+    if (widget.activeRouteSavedData != null) {
+      widget.activeRouteSavedData.saves.forEach((RecordSaveObject rso) {
+        allPreviousSaves.addAll(rso.stops);
+      });
+    }
+    // build list of stops
+    List<String> ids = stopFieldsMeta.keys.toList();
 
-    return SingleChildScrollView(
-      child: Container(
-        padding: const EdgeInsets.only(left: 10.0, right: 10.0, top: 30.0, bottom: 10.0),
-        child: Form(
-          key: _formKey,
-          child: Column(
-            children: <Widget>[
-              ActiveRouteTitleCard(
-                cardTextStyle: cardTextStyle,
-                title: widget.activeRoute.title,
-                routeMeta: routeMeta,
-                routeFields: routeFields,
-                routeFieldsForDropdown: routeFieldsForDropdown,
-                groupsMeta: groupsMeta,
-                onDropdownRouteFieldChanged: setRouteFieldForDropdown
-              ),
-              _buildStops(),
-              _buildSubmissionArea()
-            ],
-          ),
-        ),
+    int len = 2 + stopMeta.length;
+    return Container(
+      padding: const EdgeInsets.only(left: 10.0, right: 10.0, top: 30.0, bottom: 10.0),
+      // Listview *works*, but validation doesn't, since some form fields are NULL.
+      child: ListView.builder(
+        itemCount: len,
+        itemBuilder: (context, index) {
+          // first element is always the title card
+          if (index == 0) {
+            return ActiveRouteTitleCard(
+              cardTextStyle: cardTextStyle,
+              title: widget.activeRoute.title,
+              routeMeta: routeMeta,
+              routeFields: routeFields,
+              routeFieldsForDropdown: routeFieldsForDropdown,
+              groupsMeta: groupsMeta,
+              onDropdownRouteFieldChanged: setRouteFieldForDropdown
+            );
+          }
+          // last element is always the submission area
+          if (index == len - 1) {
+            return _buildSubmissionArea();
+          }
+          int stopIndex = index - 1;
+          String thisStopTitle = ids[stopIndex];
+          return ActiveRouteStop(
+            cardTextStyle: cardTextStyle,
+            title: thisStopTitle,
+            stopMeta: stopMeta,
+            stopFieldsMeta: stopFieldsMeta,
+            enabled: !allPreviousSaves.contains(thisStopTitle),
+            stopFieldsForDropdown: stopFieldsForDropdown,
+            stopFields: stopFields,
+            groupsMeta: groupsMeta,
+            onDropdownStopFieldChanged: setStopFieldForDropdown
+          );
+        }
       )
     );
   }

--- a/lib/views/active_route.dart
+++ b/lib/views/active_route.dart
@@ -656,43 +656,46 @@ class ActiveRouteState extends State<ActiveRoute> {
         allPreviousSaves.addAll(rso.stops);
       });
     }
+    // build list of stops
+    List<String> ids = stopFieldsMeta.keys.toList();
 
-    List<Widget> listViewChildren = [];
-    // first element is always the title card
-    listViewChildren.add(
-      ActiveRouteTitleCard(
-        cardTextStyle: cardTextStyle,
-        title: widget.activeRoute.title,
-        routeMeta: routeMeta,
-        routeFields: routeFields,
-        routeFieldsForDropdown: routeFieldsForDropdown,
-        groupsMeta: groupsMeta,
-        onDropdownRouteFieldChanged: setRouteFieldForDropdown
-      )
-    );
-    stopFieldsMeta.keys.forEach((String thisStopTitle) {
-      listViewChildren.add(
-        ActiveRouteStop(
-          cardTextStyle: cardTextStyle,
-          title: thisStopTitle,
-          stopMeta: stopMeta,
-          stopFieldsMeta: stopFieldsMeta,
-          enabled: !allPreviousSaves.contains(thisStopTitle),
-          stopFieldsForDropdown: stopFieldsForDropdown,
-          stopFields: stopFields,
-          groupsMeta: groupsMeta,
-          onDropdownStopFieldChanged: setStopFieldForDropdown
-        )
-      );
-    });
-    // last element is always the submission area
-    listViewChildren.add(_buildSubmissionArea());
-
+    int len = 2 + stopMeta.length;
     return Container(
       padding: const EdgeInsets.only(left: 10.0, right: 10.0, top: 30.0, bottom: 10.0),
       // Listview *works*, but validation doesn't, since some form fields are NULL.
-      child: ListView(
-        children: listViewChildren
+      child: ListView.builder(
+        itemCount: len,
+        itemBuilder: (context, index) {
+          // first element is always the title card
+          if (index == 0) {
+            return ActiveRouteTitleCard(
+              cardTextStyle: cardTextStyle,
+              title: widget.activeRoute.title,
+              routeMeta: routeMeta,
+              routeFields: routeFields,
+              routeFieldsForDropdown: routeFieldsForDropdown,
+              groupsMeta: groupsMeta,
+              onDropdownRouteFieldChanged: setRouteFieldForDropdown
+            );
+          }
+          // last element is always the submission area
+          if (index == len - 1) {
+            return _buildSubmissionArea();
+          }
+          int stopIndex = index - 1;
+          String thisStopTitle = ids[stopIndex];
+          return ActiveRouteStop(
+            cardTextStyle: cardTextStyle,
+            title: thisStopTitle,
+            stopMeta: stopMeta,
+            stopFieldsMeta: stopFieldsMeta,
+            enabled: !allPreviousSaves.contains(thisStopTitle),
+            stopFieldsForDropdown: stopFieldsForDropdown,
+            stopFields: stopFields,
+            groupsMeta: groupsMeta,
+            onDropdownStopFieldChanged: setStopFieldForDropdown
+          );
+        }
       )
     );
   }

--- a/lib/views/active_route_widgets/active_route_stop.dart
+++ b/lib/views/active_route_widgets/active_route_stop.dart
@@ -37,12 +37,6 @@ class ActiveRouteStop extends StatelessWidget {
       if (sf.type == FieldDataType.select) {
         fieldsForUserEntry.add(
             DropdownButtonFormField<String>(
-              validator: (String value) {
-                if (value == null && !sf.optional) {
-                  return 'Please enter a $stopFieldTitle.';
-                }
-                return null;
-              },
               value: stopFieldsForDropdown[title][stopFieldTitle],
               // display already-entered data if resuming route and this is disabled
               hint: enabled
@@ -70,12 +64,6 @@ class ActiveRouteStop extends StatelessWidget {
             TextFormField(
               controller: stopFields[title][stopFieldTitle],
               enabled: enabled,
-              validator: (value) {
-                if (value.isEmpty && !sf.optional) {
-                  return 'Please enter a $stopFieldTitle.';
-                }
-                return null;
-              },
               decoration: InputDecoration(
                   hintText: sf.optional ? '$stopFieldTitle (optional)' : stopFieldTitle
               ),

--- a/lib/views/active_route_widgets/active_route_title_card.dart
+++ b/lib/views/active_route_widgets/active_route_title_card.dart
@@ -30,12 +30,6 @@ class ActiveRouteTitleCard extends StatelessWidget {
       if (mf.type == FieldDataType.select) {
         theseFields.add(
           DropdownButtonFormField<String>(
-            validator: (String value) {
-              if (value == null && !mf.optional) {
-                return 'Please enter a $fieldName.';
-              }
-              return null;
-            },
             value: routeFieldsForDropdown[fieldName],
             hint: Text(fieldName),
             icon: Icon(Icons.arrow_drop_down),
@@ -57,12 +51,6 @@ class ActiveRouteTitleCard extends StatelessWidget {
         theseFields.add(
           TextFormField(
             controller: routeFields[fieldName],
-            validator: (value) {
-              if (value.isEmpty && !mf.optional) {
-                return 'Please enter a $fieldName.';
-              }
-              return null;
-            },
             decoration: InputDecoration(
               hintText: mf.optional
                 ? '$fieldName (optional)'


### PR DESCRIPTION
Speeds up the performance of the active route page. Noticeable mainly when one is scrolling.

Done by replacing scrollable `Column` with `ListView.builder`, which optimizes long lists. Our lists weren't that long, but there were so many fields that it was intensive anyway.

Because form validators (`validator` property of FormField subclasses) no longer work when offscreen (since `ListView` hasn't built them yet), a workaround is implemented. Validation now occurs in a dedicated method which is called by `_handleSubmitRoute`.

Also split up active route page into more widgets.